### PR TITLE
Add :supports_templates option

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -44,7 +44,7 @@ $ bundle install
 The main entry point is method `Asciidoctor::TemplatesCompiler::Slim#compile_converter` (for Slim) that accepts the following keyword arguments.
 
 backend_info::
-  A hash of keys for `backend_info`: `basebackend`, `outfilesuffix`, `filetype`, `htmlsyntax`.
+  A hash of keys for `backend_info`: `basebackend`, `outfilesuffix`, `filetype`, `htmlsyntax`, `supports_templates` (requires Asciidoctor ≥ 1.5.7).
 
 class_name::
   Full name of the converter class to generate (e.g. `My::HTML::Converter`).

--- a/bin/asciidoctor-templates-compiler
+++ b/bin/asciidoctor-templates-compiler
@@ -22,7 +22,8 @@ HELP_MSG = <<-EOF.unindent
 
   Options:
     -b --backend-info KEY=VAL[,...]  Parameters for backend_info: basebackend, outfilesuffix,
-                                     filetype, and htmlsyntax.
+                                     filetype, htmlsyntax, and supports_templates (requires
+                                     Asciidoctor >= 1.5.7).
 
     -n --class-name NAME             Full name of the converter class to generate (e.g.
                                      My::HTML::Converter) [default: Converter].

--- a/lib/asciidoctor/templates_compiler/converter_generator.rb
+++ b/lib/asciidoctor/templates_compiler/converter_generator.rb
@@ -36,7 +36,7 @@ module Asciidoctor::TemplatesCompiler
     # @param register_for [Array<String>] an array of backend names that the generated converter
     #   should be registered for to handle. Default is empty.
     # @param backend_info [Hash] a hash of parameters for +backend_info+: +basebackend+,
-    #   +outfilesuffix+, +filetype+, +htmlsyntax+. Default is empty.
+    #   +outfilesuffix+, +filetype+, +htmlsyntax+, +supports_templates+. Default is empty.
     # @param delegate_backend [String, nil] name of the backend (converter) to use as a fallback
     #   for AST nodes not supported by the generated converter. If not specified, no fallback will
     #   be used and converter will raise +NoMethodError+ when it try to convert unsupported node.
@@ -109,7 +109,9 @@ module Asciidoctor::TemplatesCompiler
 
     def initialization_code
       setup_backend_info = if !@backend_info.empty?
-        @backend_info.map { |k, v| "  #{k} #{v.inspect}" }.join("\n")
+        @backend_info.map { |key, value|
+          "  #{key}" + (value == true ? '' : " #{value.inspect}")
+        }.join("\n")
       end
 
       if !@register_for.empty?

--- a/spec/templates_compiler/converter_generator_spec.rb
+++ b/spec/templates_compiler/converter_generator_spec.rb
@@ -255,6 +255,19 @@ module Asciidoctor::TemplatesCompiler
               EOF
             end
           end
+
+          context 'sets boolean parameters' do
+            let(:backend_info) {{ supports_templates: true }}
+
+            it 'backend_info parameters are set without a value' do
+              is_expected.to include <<-EOF.reindent(2)
+                def initialize(backend, opts = {})
+                  super
+                  supports_templates
+                end
+              EOF
+            end
+          end
         end
 
         context 'when delegate_backend' do


### PR DESCRIPTION
Hey @jirutka 👋 As [briefly discussed on Twitter](https://twitter.com/jkreeftmeijer/status/1001935852359028736):

Introduced in Asciidoctor [1.5.7], the :supports_templates option allows
using custom converters with custom templates using the `:template_dirs`
option or the `-T` command line option.

~To enable it in a converter, it needs to call the `supports_templates`
method in its initializer. This patch adds the `:supports_templates`
option, which calls the `supports_templates` method when set to `true`.~

To enable it in a converter, it needs to call the `supports_templates`
method in its initializer without any arguments.

This patch adds the ability to set a backend_info parameter to `true`,
which will add a call to that function without any arguments.

[1.5.7]: https://github.com/asciidoctor/asciidoctor/commit/ec8e7e002be41a12f79c2e2629ac7ea15103438a