### PR TITLE
Fix tests on asciidoctor 1.5.7, include Logging

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'rspec'
 require_relative 'support/matchers'
+require 'asciidoctor/logging'
 
 RSpec.configure do |config|
   config.color = true


### PR DESCRIPTION
Tests are failing on Asciidoctor 1.5.7, caused by Asciidoctor::Logging
being included, but not required. This patch requires it in the
spec_helper to get tests to run again.