### PR TITLE
Update dependencies to reflect Asciidoctor 2.0

### DIFF
--- a/asciidoctor-templates-compiler.gemspec
+++ b/asciidoctor-templates-compiler.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.1'
 
-  s.add_runtime_dependency 'asciidoctor', '~> 1.5'
+  s.add_runtime_dependency 'asciidoctor', '>= 1.5.0', '< 2.1'
   s.add_runtime_dependency 'corefines', '~> 1.2'
   s.add_runtime_dependency 'docopt', '~> 0.6'
   s.add_runtime_dependency 'slim', '>= 2.1', '< 4.0'


### PR DESCRIPTION
Right now asciidoctor-reveal.js builds fails with asciidoctor-templates-compiler complains because of strict dependency requirements. Asciidoctor 2.0 is on the way and will be compatible with 1.5.8.

See asciidoctor/asciidoctor-reveal.js#216.

Similar to https://github.com/asciidoctor/asciidoctor-doctest/pull/18.